### PR TITLE
add obstacle msg to read sensor.other.obstacle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MSG_FILES
     CarlaActorInfo.msg
     CarlaActorList.msg
     CarlaControl.msg
+    CarlaObstacle.msg
     CarlaStatus.msg
     CarlaTrafficLightInfo.msg
     CarlaTrafficLightInfoList.msg

--- a/msg/CarlaObstacle.msg
+++ b/msg/CarlaObstacle.msg
@@ -1,0 +1,11 @@
+#
+# Copyright
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+#
+
+std_msgs/Header header
+
+float32 velocity
+float32 distance


### PR DESCRIPTION
I need to publish a new actor as sensor.other.obstacle and I need to define a new msg for it.